### PR TITLE
Fix: use column name if alias is an empty string

### DIFF
--- a/public/components/Main/main.tsx
+++ b/public/components/Main/main.tsx
@@ -138,7 +138,7 @@ export function getQueryResultsForTable(queryResults: ResponseDetail<string>[]):
               } catch (e) {
                 console.log('No alias for field ' + field);
               } finally {
-                fields[id] = alias == null ?  _.get(field, 'name') : alias;
+                fields[id] = !alias ?  _.get(field, 'name') : alias;
               }
             }
             databaseFields = fields;

--- a/release-notes/sql-workbench.release-notes-1.9.0.1.md
+++ b/release-notes/sql-workbench.release-notes-1.9.0.1.md
@@ -1,4 +1,4 @@
-## 2020-06-23 Version 1.9.0.1 (Current)
+## 2020-06-23 Version 1.9.0.1
 
 ### Bug Fixes
 - Fix: Kibana did not load properly ([#81](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/81))

--- a/release-notes/sql-workbench.release-notes-1.9.0.2.md
+++ b/release-notes/sql-workbench.release-notes-1.9.0.2.md
@@ -1,0 +1,4 @@
+## 2020-07-06 Version 1.9.0.2 (Current)
+
+### Bug Fixes
+- Fix: use column name if alias is an empty string ([#84](https://github.com/opendistro-for-elasticsearch/sql-workbench/pull/84))


### PR DESCRIPTION
*Issue #, if available:*
- #83 

*Description of changes:*
- Nested fields have an empty string as the alias in JDBC format, so let workbench display column name if alias is an empty string

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
